### PR TITLE
feat: identity tests use examples

### DIFF
--- a/src/cli/identity_test.sh
+++ b/src/cli/identity_test.sh
@@ -22,11 +22,33 @@ source ./tools/bash/unittest.bash || exit 1
 
 readonly ELF2SQL="$(rlocation __main__/src/cli/elf2sql)"
 readonly SQL2ELF="$(rlocation __main__/src/cli/sql2elf)"
+readonly EXAMPLES_DIR="$(dirname "$(rlocation __main__/src/examples/teensy)")"
 
-function test_advanced_ls() {
-  ${ELF2SQL} /usr/bin/ls || fail "elf2sql failed"
-  ${SQL2ELF} ls.db || fail "sql2elf failed"
-  ls.elf --help || fail "created invalid ELF binary"
+# TODO(fzakaria): This is shared from //tools/build_defs/test/test_return_code.sh
+# and it should be shared in a common library.
+function assert_command_outcome() {
+  binary="$1"
+  expected_outcome="$2"
+  ($binary && result_code=$?) || result_code=$?
+  if [ "$result_code" -ne 42 ]; then
+    fail "Expected return code ${expected_outcome}, but got $?."
+  fi
+}
+
+# This test assumes all the examples return 42 as their status
+# it does no functionality test aside from the return code
+# TODO(fzakaria) find a way to create multiple functions for each test example
+function test_examples_directory_simple() {
+  for example_path in "$EXAMPLES_DIR"/*; do
+    echo "Testing example: $example_path"
+    ${ELF2SQL} "$example_path" || fail "elf2sql failed"
+
+    sqlite_db="$(basename "$example_path").db"
+    elf_file="$(basename "$example_path").elf"
+
+    ${SQL2ELF} "$sqlite_db"|| fail "sql2elf failed"
+    assert_command_outcome "$elf_file" 42
+  done
 }
 
 run_suite "Test suite for identity tests"

--- a/src/examples/BUILD.bazel
+++ b/src/examples/BUILD.bazel
@@ -5,9 +5,20 @@ filegroup(
     name = "examples",
     srcs = [
         "teensy-bin",
+        # ":hello-world-asm",
         ":tiny",
     ],
     visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "hello-world-c",
+    srcs = ["hello_world.c"],
+)
+
+nasm_binary(
+    name = "hello-world-asm",
+    src = "hello_world.asm",
 )
 
 nasm_binary(

--- a/src/examples/hello_world.asm
+++ b/src/examples/hello_world.asm
@@ -1,0 +1,28 @@
+; hello_world.asm
+; Writes "Hello, World" to the console using only system calls.
+; Runs on 64-bit Linux only.
+BITS 64
+GLOBAL _start
+SECTION .rodata
+    message: db "Hello, World!", 0xa   ; for reference: 0xa = "\n"
+    len: equ $-message       ; "len" will calculate the current
+                             ; offset minus the "msg" offset.
+                             ; this should give us the size of
+                             ; "msg".
+
+SECTION .text
+_start:
+   ;######################################
+   ; syscall - write(1, msg, len);
+   ;######################################
+    mov rax, 1 ; write system call
+    mov rdi, 1 ; file descriptor (stdout)
+    mov rsi, message  ; pointer to message
+    mov rdx, len  ; length of message including newline
+    syscall
+   ;######################################
+   ; syscall - exit(0);
+   ;######################################
+    mov rax, 60 ; exit system call
+    xor rdi, rdi  ; exit status code of 0
+    syscall

--- a/src/examples/hello_world.c
+++ b/src/examples/hello_world.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello, World!\n");
+  return 42;
+}

--- a/tools/nasm/nasm.bzl
+++ b/tools/nasm/nasm.bzl
@@ -8,6 +8,9 @@ def _nasm_object_impl(ctx):
     args.add("-f", "elf64")
     args.add("-o", out.path)
 
+    args.add("-g")
+    args.add("-F", "dwarf")
+
     ctx.actions.run(
         outputs = [out],
         inputs = [src],
@@ -40,15 +43,13 @@ def nasm_binary(name, src):
         src = src,
     )
 
-    # At the moment blink the emulator has a bug where files that end in .bin
-    # are assumed to be flat files and therefore the entry point is wrong
-    # if results in a SIGSEGV.
-    out = "%s.bin" % name
+    out = name
     native.genrule(
-        name = name,
+        name = "%s-bin" % name,
         outs = [out],
         srcs = [":%s-object" % name],
-        cmd = "ld -z noseparate-code -s $< -o $@",
+        # cmd = "ld -z noseparate-code -s $< -o $@",
+        cmd = "ld -z noseparate-code $< -o $@",
         executable = True,
         message = "Creating the binary %s" % out,
     )


### PR DESCRIPTION
The identity test was still using bin/ls and also using the hacky way where we bootstrapped by inserting the whole binary.
We now do the real conversion of our minimal examples!